### PR TITLE
Fix display of dynamic value

### DIFF
--- a/RegExMatch.js
+++ b/RegExMatch.js
@@ -1,13 +1,11 @@
 var RegExMatch = function() {
 	this.evaluate = function() {
-		
-		var flags = 'g';
 
+		var flags = 'g';
 		flags += this.ignoreCase ? 'i' : '';
 		flags += this.multiline ? 'm' : '';
 
 		var regex = new RegExp(this.re, flags);
-
 
 		var m = regex.exec(this.input);
 		if(m != null) {
@@ -23,23 +21,22 @@ var RegExMatch = function() {
 		}
 	}
 
-
 	this.text = function(context) {
-		return " ➤ " + this.input;
+		if (!this.input && this.input.length === 0) {
+			return null;
+		}
+		return "➤ " + this.input;
 	}
 }
 
 RegExMatch.identifier = "com.luckymarmot.RegExMatch";
-
-RegExMatch.title = "RegEx Match";
-
+RegExMatch.title = "RegExp Match";
 RegExMatch.help = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Special_characters_meaning_in_regular_expressions";
-
 RegExMatch.inputs = [
-	InputField("re", "RegEx", "String"),
+	InputField("re", "RegExp", "String"),
 	InputField("input", "Input", "String"),
-	InputField("ignoreCase","ignore case", "Checkbox", {defaultValue: false}),
-	InputField("multiline","multiline", "Checkbox", {defaultValue: false})
+	InputField("ignoreCase","Case-insensitive", "Checkbox", {defaultValue: false}),
+	InputField("multiline","Multiline", "Checkbox", {defaultValue: false})
 ]
 
 registerDynamicValueClass(RegExMatch);


### PR DESCRIPTION
cc @nataliapanferova @hishnash 
- rename RegEx to RegExp to match [JS standard](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
- remove display of ➤ when no input is entered
- uppercase Multiline and Case-insensitive to match other input titles
